### PR TITLE
Fix Android build issue: use explicit version (16.1.0) of com.google.android.gms:play-service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
+    compile 'com.google.android.gms:play-services-gcm:16.1.0'
     compile 'org.nanohttpd:nanohttpd:2.3.1'
 }


### PR DESCRIPTION
I want to resolve #17 by explicitly declaring the version of com.google.android.gms:play-service to be used.